### PR TITLE
Fix document creation

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ Adapter.prototype.createDocument = function(initialSnapshot, cb) {
   document.latestSnapshot = initialSnapshot.id
   document.save(function(er, document) {
     if(er) return cb(er)
-    this.storeSnapshot(initialSnapshot, function(er) {
+    this.storeSnapshot(document._id, initialSnapshot, function(er) {
       if(er) return cb(er)
       cb(null, document._id)
     })

--- a/index.js
+++ b/index.js
@@ -21,8 +21,8 @@ var mongoose = require('mongoose')
 module.exports = Adapter
 
 var Document = module.exports.Document = {
-  firstSnapshot: Number
-, latestSnapshot: Number
+  firstSnapshot: String
+, latestSnapshot: String
 }
 
 var Snapshot = module.exports.Snapshot = {
@@ -30,7 +30,7 @@ var Snapshot = module.exports.Snapshot = {
 , creationDate: Date
 , contents: String
 , edit: String
-, id: Number
+, id: String
 }
 
 function Adapter(mongooseConnection) {


### PR DESCRIPTION
This pull request contains fixes for two issues I was hitting.
##### Snapshot ID was expected to be a Number according to the Mongoose schema

But the snapshot ID is a String (e.g. `15ai803j2rhc4wy4xs3j324g`) so the schema needed to be updated.  Here is the error I was getting when calling `gulf.Document.create`:

```
{ [ValidationError: Document validation failed]
  message: 'Document validation failed',
  name: 'ValidationError',
  errors:
   { firstSnapshot:
      { [CastError: Cast to Number failed for value "15ai803j2rhc4wy4xs3j324g" at path "firstSnapshot"]
        message: 'Cast to Number failed for value "15ai803j2rhc4wy4xs3j324g" at path "firstSnapshot"',
        name: 'CastError',
        kind: 'Number',
        value: '15ai803j2rhc4wy4xs3j324g',
        path: 'firstSnapshot',
        reason: undefined },
     latestSnapshot:
      { [CastError: Cast to Number failed for value "15ai803j2rhc4wy4xs3j324g" at path "latestSnapshot"]
        message: 'Cast to Number failed for value "15ai803j2rhc4wy4xs3j324g" at path "latestSnapshot"',
        name: 'CastError',
        kind: 'Number',
        value: '15ai803j2rhc4wy4xs3j324g',
        path: 'latestSnapshot',
        reason: undefined } } }

/Users/crcastle/src/collaborative-coding-conference/index.js:51
        if (createErr) { console.log('Error creating doc:'); console.log(createErr); throw createErr; }
                                                                                     ^
ValidationError: Document validation failed
    at MongooseError.ValidationError (/Users/crcastle/src/collaborative-coding-conference/node_modules/mongoose/lib/error/validation.js:22:11)
    at model.Document.invalidate (/Users/crcastle/src/collaborative-coding-conference/node_modules/mongoose/lib/document.js:1328:32)
    at model.Document.set (/Users/crcastle/src/collaborative-coding-conference/node_modules/mongoose/lib/document.js:681:10)
    at model.Object.defineProperty.set [as firstSnapshot] (/Users/crcastle/src/collaborative-coding-conference/node_modules/mongoose/lib/document.js:1629:25)
    at Adapter.createDocument (/Users/crcastle/src/collaborative-coding-conference/node_modules/gulf-mongodb/index.js:43:26)
    at History.createDocument (/Users/crcastle/src/collaborative-coding-conference/node_modules/gulf/lib/History.js:30:25)
    at Function.Document.create (/Users/crcastle/src/collaborative-coding-conference/node_modules/gulf/lib/Document.js:55:15)
    at /Users/crcastle/src/collaborative-coding-conference/index.js:50:21
    at /Users/crcastle/src/collaborative-coding-conference/node_modules/gulf/lib/Document.js:72:19
    at Adapter.<anonymous> (/Users/crcastle/src/collaborative-coding-conference/node_modules/gulf-mongodb/index.js:66:19)
    at /Users/crcastle/src/collaborative-coding-conference/node_modules/kareem/index.js:160:11
    at Query._findOne (/Users/crcastle/src/collaborative-coding-conference/node_modules/mongoose/lib/query.js:1141:12)
    at /Users/crcastle/src/collaborative-coding-conference/node_modules/kareem/index.js:156:8
    at /Users/crcastle/src/collaborative-coding-conference/node_modules/kareem/index.js:18:7
    at _combinedTickCallback (node.js:370:9)
    at process._tickCallback (node.js:401:11)
```
##### `Adapter#createDocument` was calling `Adapter#storeSnapshot` incorrectly

`storeSnapshot` required an extra parameter -- the document ID.  Here is the error I was getting for this:

```
/Users/crcastle/src/collaborative-coding-conference/node_modules/gulf-mongodb/index.js:80
    if(er) return cb(er)
                  ^

TypeError: cb is not a function
    at Adapter.<anonymous> (/Users/crcastle/src/collaborative-coding-conference/node_modules/gulf-mongodb/index.js:80:19)
    at /Users/crcastle/src/collaborative-coding-conference/node_modules/mongoose/lib/document.js:1817:19
    at handleError (/Users/crcastle/src/collaborative-coding-conference/node_modules/hooks-fixed/hooks.js:40:22)
    at _next (/Users/crcastle/src/collaborative-coding-conference/node_modules/hooks-fixed/hooks.js:46:22)
    at fnWrapper (/Users/crcastle/src/collaborative-coding-conference/node_modules/hooks-fixed/hooks.js:186:18)
    at /Users/crcastle/src/collaborative-coding-conference/node_modules/mongoose/lib/schema.js:193:13
    at complete (/Users/crcastle/src/collaborative-coding-conference/node_modules/mongoose/lib/document.js:1168:7)
    at /Users/crcastle/src/collaborative-coding-conference/node_modules/mongoose/lib/document.js:1199:20
    at ObjectId.SchemaType.doValidate (/Users/crcastle/src/collaborative-coding-conference/node_modules/mongoose/lib/schematype.js:682:12)
    at /Users/crcastle/src/collaborative-coding-conference/node_modules/mongoose/lib/document.js:1195:9
    at _combinedTickCallback (node.js:370:9)
    at process._tickCallback (node.js:401:11)
```
